### PR TITLE
[TASK] adapt composer requirements to ext_emconf settings #5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "license": ["GPL-2.0+"],
   "keywords": ["TYPO3 CMS", "TYPO3 Guide", "Guide"],
   "require": {
-    "typo3/cms-core": "~8.6.0|<8.7"
+    "typo3/cms-core": ">=8.6.1 <9"
   },
   "support": {
     "issues": "https://github.com/tdeuling/typo3-guide/issues"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "license": ["GPL-2.0+"],
   "keywords": ["TYPO3 CMS", "TYPO3 Guide", "Guide"],
   "require": {
-    "typo3/cms-core": ">=8.6.1 <9"
+    "typo3/cms-core": "^8.7"
   },
   "support": {
     "issues": "https://github.com/tdeuling/typo3-guide/issues"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '2.0.0',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '8.6.1-8.9.99'
+			'typo3' => '8.7.0-8.7.99'
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
With this it is possible to install EXT:guide with TYPO3 8.7.x.
Tested with TYPO3 8.7.3