### PR TITLE
BUGFIX Fix composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "tdeuling/guide",
+  "name": "codingms/guide",
   "description": "Guides new users through the system. New guided tours can easily be configured by page typoscript.",
   "homepage": "https://github.com/tdeuling/typo3-guide",
   "type": "typo3-cms-extension",

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,25 @@
 {
-  "name": "typo3-ter/guide",
-  "type": "typo3-cms-extension",
+  "name": "tdeuling/guide",
   "description": "Guides new users through the system. New guided tours can easily be configured by page typoscript.",
-  "version": "2.0.0",
   "homepage": "https://github.com/tdeuling/typo3-guide",
-  "license": ["GPL-2.0+"],
-  "keywords": ["TYPO3 CMS", "TYPO3 Guide", "Guide"],
+  "type": "typo3-cms-extension",
+  "license": "GPL-2.0-or-later",
   "require": {
     "typo3/cms-core": "^8.7"
   },
+  "keywords": ["TYPO3 CMS", "TYPO3 Guide", "Guide"],
   "support": {
     "issues": "https://github.com/tdeuling/typo3-guide/issues"
   },
   "autoload": {
-    "psr-4": { "Tx\\Guide\\": "Classes/"}
+    "psr-4": {
+      "Tx\\Guide\\": "Classes/"
+    }
   },
   "autoload-dev": {
-    "psr-4": { "Tx\\Guide\\Tests\\": "Tests/"}
+    "psr-4": {
+      "Tx\\Guide\\Tests\\": "Tests/"
+    }
   },
   "replace": {
     "guide": "self.version",


### PR DESCRIPTION
* Remove version key – Git tags should be used instead
* Fix license key - GPL2+ is deprecated
* Create custom name - »typo3-ter« is reserved for the
  TYPO3 fallback script which creates composer files
  if it is missing - it should not be used by extensions.

This change requires manual steps:
* Register package on packagist → Just add "https://github.com/tdeuling/typo3-guide/" on https://packagist.org/packages/submit
* Add git tags for version releases

Refs #9