### PR TITLE
FEATURE Let integrator hide a tour

### DIFF
--- a/Classes/Utility/GuideUtility.php
+++ b/Classes/Utility/GuideUtility.php
@@ -103,6 +103,14 @@ class GuideUtility
         if(count($tours) >0) {
             foreach ($tours as $tourKey => $tour) {
                 $tour['name'] = $tourKey;
+
+                // Check if tour should be hidden from the user, or if
+                // requested tour module is not enabled for current user
+                if (false === empty($tours[$tourKey]['hide']) || false === $this->moduleEnabled($tour['moduleName'])) {
+                  unset($tours[$tourKey]);
+                  continue;
+                }
+
                 // Merge user configuration
                 if (isset($backendUser->uc['moduleData']['guide'][$tour['name']])) {
                     $tours[$tour['name']] = array_merge($tour,
@@ -127,12 +135,6 @@ class GuideUtility
                 }
                 $tours[$tourKey]['stepsCount'] = count($tours[$tourKey]['steps']);
                 unset($tours[$tourKey]['steps']);
-
-                // Check if requested module is enabled for current user
-                if (!$this->moduleEnabled($tour['moduleName'])) {
-                    // …if not, remove that tour
-                    unset($tours[$tourKey]);
-                }
             }
         }
         return $tours;


### PR DESCRIPTION
See #10 

Add a TSconfig option to hide a tour to editors.

Use case:
* integrators may build and activate or disable different guided tours for different users (eg. regular user/ advanced user)
* integrators may remove tours provided by third party extensions which are not relavant for editors

Example:
Remove the tour “TemplateModule” by adding this line to the Tsconfig of a backend user:

    mod.guide.tours.TemplateModule.hide = 1

Before:
![tours-available](https://user-images.githubusercontent.com/1592995/36599562-0c431cd2-18b0-11e8-9c06-74e10e4f753f.png)

After: 
![tours-hidden](https://user-images.githubusercontent.com/1592995/36599563-0c5c6afc-18b0-11e8-9eb6-d37963be9a95.png)
